### PR TITLE
Add accepptance tests section

### DIFF
--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -79,5 +79,20 @@ Clone Daedalus repository and go to the root directory:
 
 Then run the following script: 
 
-    [nix-shell:~/cardano-sl]$ ./scripts/link-bridge.sh
-    [nix-shell:~/cardano-sl]$ npm install
+    [nix-shell:~/daedalus]$ ./scripts/link-bridge.sh
+    [nix-shell:~/daedalus]$ npm install
+
+### Running acceptance tests
+
+To run acceptance tests one first has to have cluster running. We can run cluster on our machine with:
+
+    [nix-shell:~/cardano-sl]$ ./scripts/launch/demo-with-wallet-api.sh
+
+Then navigate to daedalus repo and run tests with:
+
+    [nix-shell:~/daedalus]$ npm run hot-server
+    [nix-shell:~/daedalus]$ npm run test
+
+You should see acceptance tests being run for about 5 minutes. Note that acceptance tests will be actively be taking window focus until they are finished. If it complains about `cardano-node.log` not existing just create it in the path with:
+
+    [nix-shell:~/daedalus]$ touch ~/.config/Daedalus/Logs/cardano-node.log

--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -88,9 +88,12 @@ To run acceptance tests one first has to have cluster running. We can run cluste
 
     [nix-shell:~/cardano-sl]$ ./scripts/launch/demo-with-wallet-api.sh
 
-Then navigate to daedalus repo and run tests with:
+Then navigate to daedalus repo and run tests server with:
 
     [nix-shell:~/daedalus]$ npm run hot-server
+
+and in the seperate terminal window run tests:
+
     [nix-shell:~/daedalus]$ npm run test
 
 You should see acceptance tests being run for about 5 minutes. Note that acceptance tests will be actively be taking window focus until they are finished. If it complains about `cardano-node.log` not existing just create it in the path with:


### PR DESCRIPTION
Its a summary of https://github.com/input-output-hk/daedalus/blob/master/features/README.md and my chat with Dmitry Mukhadinov:

cardano -sl 
```
[akegalj@notebook cardano-sl]$ git log
commit 73cf4fc35d3cfb068458f2b6982990d08a99906e (HEAD -> master, origin/master, origin/HEAD)
Merge: 6396a7a2b 556d88a52
Author: Mikhail Volkhov <volhovm.cs@gmail.com>
Date:   Wed Aug 2 21:55:49 2017 +0300

    Merge pull request #1201 from input-output-hk/add-changelog-info
    
    Added information to CHANGELOG.md
```
daedalus
```
[akegalj@notebook daedalus]$ git log
commit 5c251d749c0bc19d4d067bce0b7af2bc160bfcb1 (HEAD -> master, origin/master, origin/HEAD)
Merge: ef5a455f 366a0019
Author: Ante Kegalj <akegalj@gmail.com>
Date:   Mon Jul 31 21:03:26 2017 +0100

    Merge pull request #413 from input-output-hk/akegalj/merge-0.5-to-master
    
    Akegalj/merge 0.5 to master
```

```
[akegalj@notebook cardano-sl]$ scripts/build/cardano-sl.sh
[akegalj@notebook cardano-sl]$ stack exec -- cardano-wallet-hs2purs
[akegalj@notebook cardano-sl]$ cd daedalus/
[akegalj@notebook daedalus]$ rm -rf .psci_modules/ .pulp-cache/ node_modules/ bower_components/ output/
[akegalj@notebook daedalus]$ export PATH=~/Downloads/node-v6.9.4-linux-x64/bin/:$PATH
[akegalj@notebook daedalus]$ npm install
[akegalj@notebook daedalus]$ npm run build:prod
[akegalj@notebook daedalus]$ npm unlink daedalus-client-api
[akegalj@notebook daedalus]$ npm link
[akegalj@notebook daedalus]$ npm link
```
I run `npm link` twice as I got some error from the first run all the time

then I navigate to daedalus repo
```
[akegalj@notebook daedalus]$ rm -rf .psci_modules/ .pulp-cache/ node_modules/ bower_components/ output/
[akegalj@notebook daedalus]$ export PATH=~/Downloads/node-v6.9.4-linux-x64/bin/:$PATH
[akegalj@notebook daedalus]$ npm install
[akegalj@notebook daedalus]$ npm link daedalus-client-api
[akegalj@notebook daedalus]$ npm run hot-server
```
and in another terminal
```
[akegalj@notebook daedalus]$ export PATH=~/Downloads/node-v6.9.4-linux-x64/bin/:$PATH
[akegalj@notebook daedalus]$ npm test
```
before running `npm test` run local cluster with 
```
[akegalj@notebook cardano-sl]$ scripts/launch/demo-with-wallet-api.sh 
```

after running first time `npm test` I got this error :arrow_double_down:

_ picture showing missing file error _

which was fixed by 
```
[akegalj@notebook ~]$ touch /home/akegalj/.config/Daedalus/Logs/cardano-node.log
```