### PR TITLE
for contributors | building from source:  document the pure Nix way + some restructuring

### DIFF
--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -21,11 +21,10 @@ Electron-based wallet called “Daedalus”.
 The source code for both Cardano SL and Daedalus Bridge can be obtained
 from the [official repository](https://github.com/input-output-hk/cardano-sl).
 
-Cardano SL supports three ways for building itself:
+Cardano SL supports two ways for building itself:
 
--   Pure [Nix](https://nixos.org/nix/)-based (backed by a build cache from the IOHK CI)
--   Mixed Stack+Nix mode (also cache-backed)
--   Pure [Haskell Tool Stack](https://haskellstack.org)-based
+-   (preferred) [Nix](https://nixos.org/nix/) package manager (backed by a binary cache by IOHK continuous integration)
+-   [Stack](https://haskellstack.org) with Nix for system libraries
 
 In any case, we strongly suggest using [Nix package manager](https://nixos.org/nix/download.html) to get the correct dependencies for building Cardano SL. It will fetch the correct `openssl` version, but won't override the system-installed version. The following commands assume that you already has `stack` and `nix-*` programs.
 
@@ -36,7 +35,7 @@ As a result of building Cardano SL, you will get a set of components (binary fil
 
 ## Common build steps
 
-The following steps are shared between all three methods of building Cardano: fetching source and deciding on a branch to be built.
+The following steps are shared between the two methods of building Cardano: fetching source and deciding on a branch to be built.
 
 Clone Cardano SL repository and go to the root directory:
 
@@ -47,11 +46,15 @@ Switch to the latest release branch, for example, `cardano-sl-1.0`:
 
     $ git checkout cardano-sl-1.0
 
-## Pure Nix build mode (recommended)
+## Nix build mode (recommended)
 
-Two simple steps:
+First, prerequisite: install Nix (full instructions at https://nixos.org/nix/download.html):
 
-1.  To employ the signed IOHK build cache:
+    curl https://nixos.org/nix/install | sh
+
+Two steps remain, then:
+
+1.  To employ the signed IOHK binary cache:
 
         $ sudo mkdir -p /etc/nix
         $ sudo vi /etc/nix/nix.conf       # ..or any other editor, if you prefer
@@ -67,7 +70,7 @@ Two simple steps:
 
     The build output directory will be symlinked as `cardano-sl-1.0` (as specified by the command).
 
-## Mixed Stack + Nix build mode
+## Stack with Nix for system libraries (mixed mode)
 
 Please, see the previous section on how to enable use of the IOHK binary cache.
 
@@ -82,43 +85,6 @@ And if it is the first project in Haskell on this machine, run `stack setup`:
 After that, in order to build Cardano SL with wallet capabilities, run the following script:
 
     [nix-shell:~/cardano-sl]$ ./scripts/build/cardano-sl.sh
-
-It is suggested having at least 8GB of RAM and some swap space for the build process. As the project is fairly large and GHC parallelizes builds very effectively, memory and CPU consumption during the build process is high. Please make sure you have enough free disk space as well.
-
-After the project is built - it can take quite a long time -  the built binaries can be launched using the `stack exec` command. Let's discuss important binaries briefly before proceeding to the next step.
-
-## Pure Stack-based build (not recommended)
-
-We **strongly recommend** you to use [Nix package manager](https://nixos.org/nix/download.html) to build Cardano SL (see the "Pure Nix build mode" section above), but it is possible to build it without Nix as well.
-
-Clone Cardano SL repository and go to the root directory:
-
-    $ git clone git@github.com:input-output-hk/cardano-sl.git
-    $ cd cardano-sl
-
-Switch to the latest release branch, for example, `cardano-sl-1.0`:
-
-    $ git checkout cardano-sl-1.0
-
-And if it is the first project in Haskell on this machine, run `stack setup`:
-
-    $ stack setup
-
-Now install Haskell package `cpphs`:
-
-    $ stack install cpphs
-
-After that install `rocksdb` package using your package manager, for example:
-
-    $ brew install rocksdb
-
-or
-
-    $ sudo apt-get install librocksdb-dev
-
-Then run the following script:
-
-    $ ./scripts/build/cardano-sl.sh --no-nix
 
 It is suggested having at least 8GB of RAM and some swap space for the build process. As the project is fairly large and GHC parallelizes builds very effectively, memory and CPU consumption during the build process is high. Please make sure you have enough free disk space as well.
 

--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -87,6 +87,11 @@ NOTE: the various other Cardano components can be obtained through other attribu
 -  `cardano-sl-wallet`:
    - `cardano-node`, `cardano-wallet-hs2purs`, `cardano-swagger`
 
+In general, for any given cabal `PACKAGE` provided by Cardano, there is a
+corresponding Nix attribute for it -- `PACKAGE`, and sometimes, in case of
+packages providing executables, the `PACKAGE-static` also provides a
+statically-linked variation.
+
 ## Stack with Nix for system libraries (mixed mode)
 
 Please, see the previous section on how to enable use of the IOHK binary cache.
@@ -133,7 +138,7 @@ Clone Daedalus repository and go to the root directory:
     [nix-shell:~/cardano-sl]$ git clone https://github.com/input-output-hk/daedalus.git
     [nix-shell:~/cardano-sl]$ cd daedalus
 
-Then run the following script: 
+Then run the following script:
 
     [nix-shell:~/daedalus]$ ./scripts/link-bridge.sh
     [nix-shell:~/daedalus]$ npm install

--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -71,7 +71,7 @@ Two steps remain, then:
 
     The build output directory will be symlinked as `cardano-sl-1.0` (as specified by the command), and it will contain:
 
-        $ ls cardano-sl-1.0
+        $ ls cardano-sl-1.0/bin
         cardano-node-simple
 
 NOTE: the various other Cardano components can be obtained through other attributes:

--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -21,14 +21,22 @@ Electron-based wallet called “Daedalus”.
 The source code for both Cardano SL and Daedalus Bridge can be obtained
 from the [official repository](https://github.com/input-output-hk/cardano-sl).
 
-The [Haskell Tool Stack](https://haskellstack.org) is required to build Cardano SL. Furthermore, we strongly suggest using [Nix package manager](https://nixos.org/nix/download.html) to get the correct dependencies for building Cardano SL. It will fetch the correct `openssl` version, but won't override the system-installed version. The following commands assume that you already has `stack` and `nix-*` programs.
+Cardano SL supports three ways for building itself:
+
+-   Pure [Nix](https://nixos.org/nix/)-based (backed by a build cache from the IOHK CI)
+-   Mixed Stack+Nix mode (also cache-backed)
+-   Pure [Haskell Tool Stack](https://haskellstack.org)-based
+
+In any case, we strongly suggest using [Nix package manager](https://nixos.org/nix/download.html) to get the correct dependencies for building Cardano SL. It will fetch the correct `openssl` version, but won't override the system-installed version. The following commands assume that you already has `stack` and `nix-*` programs.
 
 ### Binaries
 
 As a result of building Cardano SL, you will get a set of components (binary files). This set includes the main node for Cardano SL network and various helper tools. Please read [this page of the documentation](https://cardanodocs.com/technical/cli-options/) for technical details.
 <!-- CARDANO_SL_README_END_4 -->
 
-## Build Commands
+## Common build steps
+
+The following steps are shared between all three methods of building Cardano: fetching source and deciding on a branch to be built.
 
 Clone Cardano SL repository and go to the root directory:
 
@@ -39,7 +47,31 @@ Switch to the latest release branch, for example, `cardano-sl-1.0`:
 
     $ git checkout cardano-sl-1.0
 
-Then enter `nix-shell`:
+## Pure Nix build mode (recommended)
+
+Two simple steps:
+
+1.  To employ the signed IOHK build cache:
+
+        $ sudo mkdir -p /etc/nix
+        $ sudo vi /etc/nix/nix.conf       # ..or any other editor, if you prefer
+
+    ..and then add two following lines:
+
+        $ binary-caches             = https://cache.nixos.org https://hydra.iohk.io
+        $ binary-caches-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+
+2.  Actually building Cardano SL (or, most likely, simply obtaining it from the IOHK's binary caches) can be performed by:
+
+        $ nix-build -A cardano-sl-static --cores 0 --jobs 2 --no-build-output --out-link cardano-sl-1.0
+
+    The build output directory will be symlinked as `cardano-sl-1.0` (as specified by the command).
+
+## Mixed Stack + Nix build mode
+
+Please, see the previous section on how to enable use of the IOHK binary cache.
+
+Enter `nix-shell`:
 
     $ nix-shell
 
@@ -55,9 +87,9 @@ It is suggested having at least 8GB of RAM and some swap space for the build pro
 
 After the project is built - it can take quite a long time -  the built binaries can be launched using the `stack exec` command. Let's discuss important binaries briefly before proceeding to the next step.
 
-### Build Commands without Nix
+## Pure Stack-based build (not recommended)
 
-We **strongly recommend** you to use [Nix package manager](https://nixos.org/nix/download.html) to build Cardano SL, but it is possible to build it without Nix as well.
+We **strongly recommend** you to use [Nix package manager](https://nixos.org/nix/download.html) to build Cardano SL (see the "Pure Nix build mode" section above), but it is possible to build it without Nix as well.
 
 Clone Cardano SL repository and go to the root directory:
 

--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -97,7 +97,7 @@ Enter `nix-shell`:
 
 And if it is the first project in Haskell on this machine, run `stack setup`:
 
-    [nix-shell:~/cardano-sl]$ stack setup
+    [nix-shell:~/cardano-sl]$ stack setup --nix
 
 After that, in order to build Cardano SL with wallet capabilities, run the following script:
 

--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -64,11 +64,28 @@ Two steps remain, then:
         $ binary-caches             = https://cache.nixos.org https://hydra.iohk.io
         $ binary-caches-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
-2.  Actually building Cardano SL (or, most likely, simply obtaining it from the IOHK's binary caches) can be performed by:
+2.  Actually building the Cardano SL node (or, most likely, simply obtaining it
+    from the IOHK's binary caches) can be performed by building the attribute `cardano-sl-static`:
 
         $ nix-build -A cardano-sl-static --cores 0 --jobs 2 --no-build-output --out-link cardano-sl-1.0
 
-    The build output directory will be symlinked as `cardano-sl-1.0` (as specified by the command).
+    The build output directory will be symlinked as `cardano-sl-1.0` (as specified by the command), and it will contain:
+
+        $ ls cardano-sl-1.0
+        cardano-node-simple
+
+NOTE: the various other Cardano components can be obtained through other attributes:
+
+-  `cardano-report-server-static`:
+   - `cardano-report-server`
+-  `cardano-sl-auxx`:
+   - `cardano-hash-installer`, `cardano-auxx`
+-  `cardano-sl-explorer-static`:
+   - `cardano-explorer`, `cardano-explorer-hs2purs`, `cardano-explorer-swagger`, `cardano-explorer-mock`
+-  `cardano-sl-tools-static`:
+   - `cardano-analyzer`, `cardano-dht-keygen`, `cardano-genupdate`, `cardano-keygen`, `cardano-launcher`, `cardano-addr-convert`, `cardano-cli-docs`, `cardano-block-gen`, `cardano-post-mortem`
+-  `cardano-sl-wallet`:
+   - `cardano-node`, `cardano-wallet-hs2purs`, `cardano-swagger`
 
 ## Stack with Nix for system libraries (mixed mode)
 


### PR DESCRIPTION
Besides documenting the pure-Nix build method (with IOHK binary cache enablement), this also clarifies the build method nomenclature -- we actually have ~three~ two ways to build `cardano-sl`:

- purely Nix-based
- mixed `nix-shell` + Stack