### PR TITLE
Update building from source link

### DIFF
--- a/_docs/for-contributors/2017-01-01-building-from-source.md
+++ b/_docs/for-contributors/2017-01-01-building-from-source.md
@@ -8,5 +8,5 @@ group: for-contributors
 # Redirecting...
 
 <script>
-    window.location.replace("https://github.com/input-output-hk/cardano-sl/blob/master/docs/how-to/build-cardano-sl-and-daedalus-from-source-code.md");
+    window.location.replace("https://github.com/input-output-hk/cardano-sl/blob/master/docs/how-to/build-cardano-sl-core-from-scratch.md");
 </script>


### PR DESCRIPTION
The documentation moved months ago, so this would give a 404 not found
error.