### PR TITLE
[CBR-141] Add summary pointing to v0 & v1 docs at /technical/wallet/api

### DIFF
--- a/_docs/technical/wallet/2018-03-14-api-docs.md
+++ b/_docs/technical/wallet/2018-03-14-api-docs.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: API Documentation
+permalink: /technical/wallet/api
+group: technical
+language: en
+---
+
+API Documentation
+-----------------
+
+
+V0 (deprecated)
+===============
+
+The API documentation for v0, now deprecated, has been moved [here](/technical/wallet/api/v0).
+
+
+
+V1 (beta)
+=========
+
+The API documentation for v1, currently in beta-release, is available [here](/technical/wallet/api/v1).


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5680256/37404621-a959d448-2792-11e8-902d-dfa5aea4b857.png)
