### PR TITLE
fix strict-url routing for wallet's API summary

### DIFF
--- a/_docs/technical/wallet/2018-03-14-api-docs.md
+++ b/_docs/technical/wallet/2018-03-14-api-docs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: API Documentation
-permalink: /technical/wallet/api
+permalink: /technical/wallet/api/
 group: technical
 language: en
 ---


### PR DESCRIPTION
It's compiling on the other side, so I've got a bit of time to do this before it gets forgotten ^.^

The missing trailing slash in `permalink` makes urls with fragments or with a trailing slash invalid; resulting in 404 page instead of the correct target page. Adding one fixes the behavior and will correctly serve the following links:

- https://cardanodocs.com/technical/wallet/api
- https://cardanodocs.com/technical/wallet/api/
- https://cardanodocs.com/technical/wallet/api/#